### PR TITLE
Refactor indentString to avoid global variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work
 # Coverage report
 coverage.*
 *.profile
+*.benchmark

--- a/types.go
+++ b/types.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-var indentation int
-
 type Duration struct {
 	time.Duration
 }
@@ -97,31 +95,33 @@ func (i Identifier) String() string {
 func (cc *CheckCommand) String() string {
 	var bla strings.Builder
 
+	var indentation int
+
 	bla.WriteString("object CheckCommand \"" + cc.Name + "\" {\n")
 
 	indentation++
 
 	for _, cci := range cc.Imports {
-		bla.WriteString(indentString() + "import \"" + cci.Name + "\"\n")
+		bla.WriteString(indentString(indentation) + "import \"" + cci.Name + "\"\n")
 	}
 
-	bla.WriteString(indentString() + "command = " + cc.Command.String() + "\n")
+	bla.WriteString(indentString(indentation) + "command = " + cc.Command.String() + "\n")
 
-	bla.WriteString(indentString() + "arguments = {\n")
+	bla.WriteString(indentString(indentation) + "arguments = {\n")
 	indentation++
 
 	for i := range cc.Arguments {
-		bla.WriteString(cc.Arguments[i].String(cc.Name))
+		bla.WriteString(cc.Arguments[i].String(indentation, cc.Name))
 		bla.WriteString("\n")
 	}
 
 	indentation--
 
-	bla.WriteString(indentString() + "}\n")
+	bla.WriteString(indentString(indentation) + "}\n")
 
 	indentation--
 
-	bla.WriteString(indentString() + "}\n")
+	bla.WriteString(indentString(indentation) + "}\n")
 
 	return bla.String()
 }
@@ -145,74 +145,74 @@ func (ia *Array) String() string {
 	return b.String()
 }
 
-func (cca *CheckCommandArgument) String(prefix string) string {
+func (cca *CheckCommandArgument) String(indentation int, prefix string) string {
 	var b strings.Builder
 
-	b.WriteString(indentString() + "\"" + cca.Name + "\" = {\n")
+	b.WriteString(indentString(indentation) + "\"" + cca.Name + "\" = {\n")
 
 	indentation++
 
 	if cca.Value != "" {
 		if prefix != "" {
-			b.WriteString(indentString() + "value = \"$" + prefix + "_" + strings.ReplaceAll(cca.Value, "-", "_") + "$\"\n")
+			b.WriteString(indentString(indentation) + "value = \"$" + prefix + "_" + strings.ReplaceAll(cca.Value, "-", "_") + "$\"\n")
 		} else {
-			b.WriteString(indentString() + "value = \"$" + strings.ReplaceAll(cca.Value, "-", "_") + "$\"\n")
+			b.WriteString(indentString(indentation) + "value = \"$" + strings.ReplaceAll(cca.Value, "-", "_") + "$\"\n")
 		}
 	} else {
-		b.WriteString(indentString() + "value = \"\"\n")
+		b.WriteString(indentString(indentation) + "value = \"\"\n")
 	}
 
 	if cca.Description != "" {
-		b.WriteString(indentString() + "description = " + cca.Description.String() + "\n")
+		b.WriteString(indentString(indentation) + "description = " + cca.Description.String() + "\n")
 	}
 
 	if cca.Required {
-		b.WriteString(indentString() + "required = true\n")
+		b.WriteString(indentString(indentation) + "required = true\n")
 	}
 
 	if cca.SkipKey {
-		b.WriteString(indentString() + "skip_key = true\n")
+		b.WriteString(indentString(indentation) + "skip_key = true\n")
 	}
 
 	if cca.SetIf != nil {
 		switch tmp := cca.SetIf.(type) {
 		case String:
 			if prefix != "" {
-				b.WriteString(indentString() + "set_if = \"$" + prefix + "_" + strings.ReplaceAll(tmp.RawString(), "-", "_") + "$\"\n")
+				b.WriteString(indentString(indentation) + "set_if = \"$" + prefix + "_" + strings.ReplaceAll(tmp.RawString(), "-", "_") + "$\"\n")
 			} else {
-				b.WriteString(indentString() + "set_if = \"$" + strings.ReplaceAll(tmp.RawString(), "-", "_") + "$\"\n")
+				b.WriteString(indentString(indentation) + "set_if = \"$" + strings.ReplaceAll(tmp.RawString(), "-", "_") + "$\"\n")
 			}
 		case Boolean:
-			b.WriteString(indentString() + "set_if = " + tmp.String() + "\n")
+			b.WriteString(indentString(indentation) + "set_if = " + tmp.String() + "\n")
 		default:
 		}
 	}
 
 	if cca.Order != 0 {
-		b.WriteString(indentString() + "order = " + fmt.Sprintf("%d", cca.Order) + "\n")
+		b.WriteString(indentString(indentation) + "order = " + fmt.Sprintf("%d", cca.Order) + "\n")
 	}
 
 	if !cca.RepeatKey {
-		b.WriteString(indentString() + "repeat_key = false\n")
+		b.WriteString(indentString(indentation) + "repeat_key = false\n")
 	}
 
 	if cca.Key != "" {
-		b.WriteString(indentString() + "key = \"" + cca.Key + "\"\n")
+		b.WriteString(indentString(indentation) + "key = \"" + cca.Key + "\"\n")
 	}
 
 	if cca.Separator != "" {
-		b.WriteString(indentString() + "separator = \"" + cca.Separator + "\"\n")
+		b.WriteString(indentString(indentation) + "separator = \"" + cca.Separator + "\"\n")
 	}
 
 	indentation--
 
-	b.WriteString(indentString() + "}")
+	b.WriteString(indentString(indentation) + "}")
 
 	return b.String()
 }
 
-func indentString() string {
-	return strings.Repeat("\t", indentation)
+func indentString(i int) string {
+	return strings.Repeat("\t", i)
 }
 
 func (op *Operator) String() string {

--- a/types_test.go
+++ b/types_test.go
@@ -29,7 +29,7 @@ func TestCheckCommandArgument(t *testing.T) {
 	repeat_key = false
 }`
 
-	assertEqualString(t, resultString, cca.String(""))
+	assertEqualString(t, resultString, cca.String(0, ""))
 }
 
 func TestString(t *testing.T) {
@@ -57,6 +57,38 @@ func TestArray(t *testing.T) {
 	}
 
 	assertEqualString(t, "[\"foo\"]", ia3.String())
+}
+
+func BenchmarkCheckCommandString(b *testing.B) {
+	b.ReportAllocs()
+
+	cc := CheckCommand{
+		Name:    "MyPlugin",
+		Command: Array{Identifier("PluginContribDir"), String("check_myPlugin")},
+		Vars:    Dictionary{Identifier("var1"): Integer(56)},
+		Timeout: Duration{time.Duration(30 * time.Second)},
+		Arguments: []CheckCommandArgument{
+			{
+				Name:        "--foo",
+				Value:       "foo_val",
+				Description: String("hello\nneighbour"),
+				Required:    false,
+				SetIf:       String("bla_foo_bool"),
+				Order:       5,
+			},
+			{
+				Name:        "--bla",
+				Value:       "bla_val",
+				Description: "ciao",
+				Required:    true,
+				SetIf:       String("bla_foo_bool"),
+			},
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = cc.String()
+	}
 }
 
 func TestCheckCommand(t *testing.T) {


### PR DESCRIPTION
Tried to refactor to remove the global variable.

Seems to make no performance difference:

```
go test -run=. -bench=. -count=10 .

# Global Var
BenchmarkCheckCommandString-8   	  566899	      1960 ns/op	    2152 B/op	      39 allocs/op
BenchmarkCheckCommandString-8   	  635802	      1965 ns/op	    2152 B/op	      39 allocs/op

# Passed Var
BenchmarkCheckCommandString-8   	  551116	      2077 ns/op	    2152 B/op	      39 allocs/op
BenchmarkCheckCommandString-8   	  512884	      1994 ns/op	    2152 B/op	      39 allocs/op
```

```
benchstat global-var.benchmark pass-var2.benchmark
goos: linux
goarch: amd64
pkg: github.com/NETWAYS/go-icingadsl
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
                     │ global-var.benchmark │        pass-var.benchmark         │
                     │        sec/op        │   sec/op     vs base               │
CheckCommandString-8            1.959µ ± 2%   2.019µ ± 3%  +3.11% (p=0.000 n=12)

                     │ global-var.benchmark │       pass-var2.benchmark        │
                     │         B/op         │     B/op      vs base            │
CheckCommandString-8           2.102Ki ± 0%   2.102Ki ± 0%  ~ (p=1.000 n=12) ¹
¹ all samples are equal

                     │ global-var.benchmark │      pass-var2.benchmark       │
                     │      allocs/op       │ allocs/op   vs base            │
CheckCommandString-8             39.00 ± 0%   39.00 ± 0%  ~ (p=1.000 n=12) ¹
¹ all samples are equal
```
