### PR TITLE
Change FormatNotificationType to be Stringer interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,9 @@ issues:
     - path: 'convert/bytes_common.go'
       linters:
         - ireturn
+    - path: 'CheckCommandArgument.go'
+      linters:
+        - goconst
 linters:
    enable-all: true
    disable:

--- a/CheckCommandArgument.go
+++ b/CheckCommandArgument.go
@@ -1,7 +1,7 @@
 package icingadsl
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -65,7 +65,7 @@ func (cca *CheckCommandArgument) String(prefix string) string {
 	}
 
 	if cca.Order != 0 {
-		b.WriteString(indentString() + "order = " + fmt.Sprintf("%d", cca.Order) + "\n")
+		b.WriteString(indentString() + "order = " + strconv.Itoa(cca.Order) + "\n")
 	}
 
 	if !cca.RepeatKey {

--- a/Notifications.go
+++ b/Notifications.go
@@ -51,27 +51,27 @@ func ParseNotificationType(nt string) (NotificationType, error) {
 /*
  * Transforms a notification type into a string
  */
-func FormatNotificationType(nt NotificationType) (string, error) {
+func (nt NotificationType) String() string {
 	switch nt {
 	case DowntimeStart:
-		return "downtimestart", nil
+		return "downtimestart"
 	case DowntimeEnd:
-		return "downtimeend", nil
+		return "downtimeend"
 	case DowntimeRemoved:
-		return "downtimeremoved", nil
+		return "downtimeremoved"
 	case Custom:
-		return "custom", nil
+		return "custom"
 	case Acknowledgement:
-		return "acknowledgement", nil
+		return "acknowledgement"
 	case Problem:
-		return "problem", nil
+		return "problem"
 	case Recovery:
-		return "recovery", nil
+		return "recovery"
 	case FlappingStart:
-		return "flappingstart", nil
+		return "flappingstart"
 	case FlappingEnd:
-		return "flappingend", nil
+		return "flappingend"
 	default:
-		return "", errors.New("no matching state for the provided number")
+		return ""
 	}
 }

--- a/Notifications_test.go
+++ b/Notifications_test.go
@@ -1,0 +1,111 @@
+package icingadsl
+
+import (
+	"testing"
+)
+
+func TestParseNotificationType(t *testing.T) {
+	testcases := []struct {
+		expected NotificationType
+		nt       string
+	}{
+		{
+			expected: DowntimeStart,
+			nt:       "downtimestart",
+		},
+		{
+			expected: DowntimeEnd,
+			nt:       "downtimeend",
+		},
+		{
+			expected: DowntimeRemoved,
+			nt:       "downtimeremoved",
+		},
+		{
+			expected: Custom,
+			nt:       "custom",
+		},
+		{
+			expected: Acknowledgement,
+			nt:       "acknowledgement",
+		},
+		{
+			expected: Problem,
+			nt:       "problem",
+		},
+		{
+			expected: Recovery,
+			nt:       "recovery",
+		},
+		{
+			expected: FlappingStart,
+			nt:       "flappingstart",
+		},
+		{
+			expected: FlappingEnd,
+			nt:       "flappingend",
+		},
+	}
+
+	for _, tc := range testcases {
+		nt, err := ParseNotificationType(tc.nt)
+
+		if err != nil {
+			t.Error("Did not expect error, got:", err)
+		}
+
+		if nt != tc.expected {
+			t.Error("\nActual: ", nt, "\nExpected: ", tc.expected)
+		}
+	}
+}
+
+func TestNotificationTypeStringer(t *testing.T) {
+	testcases := []struct {
+		nt       NotificationType
+		expected string
+	}{
+		{
+			nt:       DowntimeStart,
+			expected: "downtimestart",
+		},
+		{
+			nt:       DowntimeEnd,
+			expected: "downtimeend",
+		},
+		{
+			nt:       DowntimeRemoved,
+			expected: "downtimeremoved",
+		},
+		{
+			nt:       Custom,
+			expected: "custom",
+		},
+		{
+			nt:       Acknowledgement,
+			expected: "acknowledgement",
+		},
+		{
+			nt:       Problem,
+			expected: "problem",
+		},
+		{
+			nt:       Recovery,
+			expected: "recovery",
+		},
+		{
+			nt:       FlappingStart,
+			expected: "flappingstart",
+		},
+		{
+			nt:       FlappingEnd,
+			expected: "flappingend",
+		},
+	}
+
+	for _, tc := range testcases {
+		if tc.nt.String() != tc.expected {
+			t.Error("\nActual: ", tc.nt.String(), "\nExpected: ", tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
Removes the FormatNotificationType fucntion in favor of the Stringer interface. This makes the code more idiomatic and formating NotificationTypes more expressive. Examples:

```golang
p = Problem
p.String()
fmt.Sprinf("%s", p)
```

Also in this PR a fmt.Sprintf was replaces with strconv.Itoa. Cleaner and faster.